### PR TITLE
feat: Add growth indicators to dashboard

### DIFF
--- a/src/components/ui/growth-indicator.tsx
+++ b/src/components/ui/growth-indicator.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+import { cn } from "@/lib/utils";
+
+interface GrowthIndicatorProps {
+  growth: number;
+  comparisonLabel: string;
+  className?: string;
+}
+
+export const GrowthIndicator: React.FC<GrowthIndicatorProps> = ({
+  growth,
+  comparisonLabel,
+  className,
+}) => {
+  const formatGrowth = (value: number) => {
+    if (value === 0) return "0.00%";
+    const sign = value > 0 ? "+" : "";
+    return `${sign}${value.toFixed(2)}%`;
+  };
+
+  const getGrowthColor = (value: number) => {
+    if (value > 0) return "text-green-600 dark:text-green-400";
+    if (value < 0) return "text-red-600 dark:text-red-400";
+    return "text-muted-foreground";
+  };
+
+  return (
+    <div className={cn("text-xs", className)}>
+      <span className={getGrowthColor(growth)}>
+        {formatGrowth(growth)}
+      </span>
+      <span className="text-muted-foreground ml-1">
+        {comparisonLabel}
+      </span>
+    </div>
+  );
+};

--- a/supabase/migrations/20250902194447_7e2f3f02-7d2e-4b49-bbf7-caff3774bf82.sql
+++ b/supabase/migrations/20250902194447_7e2f3f02-7d2e-4b49-bbf7-caff3774bf82.sql
@@ -1,0 +1,8 @@
+-- Drop the current policy with performance issue
+DROP POLICY IF EXISTS "Users can update their own profile" ON public.profiles;
+
+-- Recreate the policy with optimized expression for better performance
+CREATE POLICY "Users can update their own profile" 
+ON public.profiles 
+FOR UPDATE 
+USING (user_id = (SELECT auth.uid()));


### PR DESCRIPTION
Implement growth rate calculations and display for dashboard metrics. This includes extending calculations to all metrics, updating data fetching for period comparisons, creating a reusable growth display component, and modifying metric cards to show both existing text and new growth indicators.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a compact Growth Indicator that displays colored percentage changes with a comparison label.
  * Dashboard now shows per-metric growth for actual/pending revenue, total sales, actual/pending profit, and average sale, with a unified comparison period label.
  * Sales chart enhanced to include actual sales and actual profit series.

* **Chores**
  * Updated profile update permissions to ensure only the account owner can modify their profile.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->